### PR TITLE
Create delete-reinitialize-database to close #10845

### DIFF
--- a/scripts/setup/delete-reinitialize-database
+++ b/scripts/setup/delete-reinitialize-database
@@ -1,0 +1,27 @@
+#! /bin/bash -ex
+
+cat <<EOF
+This script will completely wipe your database, including all users, chat
+messages, and metadata.  It will not modify your existing /etc/zulip
+configuration files, but all other database-backed data will disappear. This
+script is targeting /home/zulip/deployments/current.
+
+Do you want to continue? You must type YES.
+EOF
+
+read yesno
+
+if [ "x$yesno" != "xYES" ]; then
+  >&2 echo "Exiting without changes."
+  exit 1;
+fi
+
+if [ "x$(sudo whoami)" != "xroot" ]; then
+  >&2 echo "Exiting because root is not available."
+  exit 1
+fi
+
+cat << EOF | sudo -sE
+/home/zulip/deployments/current/scripts/setup/postgres-init-db
+/home/zulip/deployments/current/scripts/setup/initialize-database
+EOF


### PR DESCRIPTION
A common thing that comes up is someone first installs Zulip, tests it out without importing their data, and then wants to convert their install into one that has its data imported from somewhere else, necessitating a complete wipe and re-initialization of the database.

This script resolves that issue with confirmations and complete hard-coded paths, which are necessary because the scripts do some `basename` mutilations. See also https://github.com/zulip/zulip/issues/10834

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
